### PR TITLE
Fix missing put method

### DIFF
--- a/boomi/_http.py
+++ b/boomi/_http.py
@@ -106,6 +106,10 @@ class _HTTP:
         kw.setdefault("headers", self.h_json)
         return self._request("DELETE", path, **kw)
 
+    def put(self, path: str, **kw):
+        kw.setdefault("headers", self.h_json)
+        return self._request("PUT", path, **kw)
+
     # ------------------------------------------------------------------ #
     # transparent pagination for /query + /queryMore
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- add missing PUT verb to HTTP helper

## Testing
- `python -m compileall boomi`
- `pip install -e .` *(fails: Could not install build dependencies)*