### PR TITLE
Add models for execution resources

### DIFF
--- a/boomi/models/__init__.py
+++ b/boomi/models/__init__.py
@@ -1,11 +1,27 @@
-from .component import Component 
-from .execution import ExecutionRecord
+from .component import Component
+from .execution import (
+    ExecutionRecord,
+    ExecutionSummaryRecord,
+    ExecutionConnector,
+    GenericConnectorRecord,
+    ExecutionCountAccount,
+    ExecutionCountAccountGroup,
+    AuditLog,
+    Event,
+)
 from .folder import Folder
 from .deployment import Deployment
 
 __all__ = [
     "Component",
     "ExecutionRecord",
+    "ExecutionSummaryRecord",
+    "ExecutionConnector",
+    "GenericConnectorRecord",
+    "ExecutionCountAccount",
+    "ExecutionCountAccountGroup",
+    "AuditLog",
+    "Event",
     "Folder",
     "Deployment",
 ]

--- a/boomi/models/execution.py
+++ b/boomi/models/execution.py
@@ -1,6 +1,57 @@
 from pydantic import BaseModel, Field
+from typing import Optional
 
 class ExecutionRecord(BaseModel):
     id: str = Field(..., alias="executionId")
     status: str
     started_at: str
+
+class ExecutionSummaryRecord(BaseModel):
+    process_id: str = Field(..., alias="processID")
+    process_name: str = Field(..., alias="processName")
+    status: Optional[str] = None
+    atom_id: Optional[str] = Field(None, alias="atomID")
+    atom_name: Optional[str] = Field(None, alias="atomName")
+    time_block: Optional[str] = Field(None, alias="timeBlock")
+
+class ExecutionConnector(BaseModel):
+    id: str
+    execution_id: str = Field(..., alias="executionId")
+    connector_type: Optional[str] = Field(None, alias="connectorType")
+    action_type: Optional[str] = Field(None, alias="actionType")
+    success_count: Optional[int] = Field(None, alias="successCount")
+    error_count: Optional[int] = Field(None, alias="errorCount")
+
+class GenericConnectorRecord(BaseModel):
+    id: str
+    execution_id: str = Field(..., alias="executionId")
+    execution_connector_id: Optional[str] = Field(None, alias="executionConnectorId")
+    status: Optional[str] = None
+    error_message: Optional[str] = Field(None, alias="errorMessage")
+    connector_type: Optional[str] = Field(None, alias="connectorType")
+    connection_name: Optional[str] = Field(None, alias="connectionName")
+
+class ExecutionCountAccount(BaseModel):
+    account_id: str = Field(..., alias="accountId")
+    atom_id: Optional[str] = Field(None, alias="atomId")
+    date: Optional[str] = None
+    failures: Optional[int] = None
+    successes: Optional[int] = None
+
+class ExecutionCountAccountGroup(ExecutionCountAccount):
+    pass
+
+class AuditLog(BaseModel):
+    document_id: Optional[str] = Field(None, alias="documentId")
+    action: Optional[str] = None
+    date: Optional[str] = None
+    level: Optional[str] = None
+    message: Optional[str] = None
+
+class Event(BaseModel):
+    event_id: str = Field(..., alias="eventId")
+    event_type: str = Field(..., alias="eventType")
+    event_level: Optional[str] = Field(None, alias="eventLevel")
+    execution_id: Optional[str] = Field(None, alias="executionId")
+    atom_name: Optional[str] = Field(None, alias="atomName")
+    process_name: Optional[str] = Field(None, alias="processName")

--- a/boomi/resources/runs.py
+++ b/boomi/resources/runs.py
@@ -3,6 +3,137 @@ from .._http import _HTTP
 class Runs:
     def __init__(self, http: _HTTP):
         self._ = http
+
     list = lambda s, body: s._.post("/ExecutionRecord/query", json=body).json()
-    log = lambda s, exec_id: s._.post("/ProcessLog",
-        json={"executionId": exec_id, "logLevel": "ALL"}).json().get("url")
+    list_more = lambda s, token: s._.post(
+        "/ExecutionRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    summary = lambda s, body: s._.post(
+        "/ExecutionSummaryRecord/query", json=body
+    ).json()
+    summary_more = lambda s, token: s._.post(
+        "/ExecutionSummaryRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    connectors = lambda s, body: s._.post(
+        "/ExecutionConnector/query", json=body
+    ).json()
+    connectors_more = lambda s, token: s._.post(
+        "/ExecutionConnector/queryMore", json={"queryToken": token}
+    ).json()
+
+    count_account = lambda s, body: s._.post(
+        "/ExecutionCountAccount/query", json=body
+    ).json()
+    count_account_more = lambda s, token: s._.post(
+        "/ExecutionCountAccount/queryMore", json={"queryToken": token}
+    ).json()
+
+    count_group = lambda s, body: s._.post(
+        "/ExecutionCountAccountGroup/query", json=body
+    ).json()
+    count_group_more = lambda s, token: s._.post(
+        "/ExecutionCountAccountGroup/queryMore", json={"queryToken": token}
+    ).json()
+
+    artifacts = lambda s, exec_id: s._.post(
+        "/ExecutionArtifacts", json={"executionId": exec_id}
+    ).json().get("url")
+
+    request = lambda s, body: s._.post("/ExecutionRequest", json=body).json()
+
+    doc = lambda s, gid: s._.get(f"/GenericConnectorRecord/{gid}").json()
+    docs = lambda s, body: s._.post(
+        "/GenericConnectorRecord/query", json=body
+    ).json()
+    docs_more = lambda s, token: s._.post(
+        "/GenericConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    as2_records = lambda s, body: s._.post(
+        "/AS2ConnectorRecord/query", json=body
+    ).json()
+    as2_records_more = lambda s, token: s._.post(
+        "/AS2ConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    edicustom_records = lambda s, body: s._.post(
+        "/EdiCustomConnectorRecord/query", json=body
+    ).json()
+    edicustom_records_more = lambda s, token: s._.post(
+        "/EdiCustomConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    edifact_records = lambda s, body: s._.post(
+        "/EDIFACTConnectorRecord/query", json=body
+    ).json()
+    edifact_records_more = lambda s, token: s._.post(
+        "/EDIFACTConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    hl7_records = lambda s, body: s._.post(
+        "/HL7ConnectorRecord/query", json=body
+    ).json()
+    hl7_records_more = lambda s, token: s._.post(
+        "/HL7ConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    odette_records = lambda s, body: s._.post(
+        "/ODETTEConnectorRecord/query", json=body
+    ).json()
+    odette_records_more = lambda s, token: s._.post(
+        "/ODETTEConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    oftp2_records = lambda s, body: s._.post(
+        "/OFTP2ConnectorRecord/query", json=body
+    ).json()
+    oftp2_records_more = lambda s, token: s._.post(
+        "/OFTP2ConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    rosetta_records = lambda s, body: s._.post(
+        "/RosettaNetConnectorRecord/query", json=body
+    ).json()
+    rosetta_records_more = lambda s, token: s._.post(
+        "/RosettaNetConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    tradacoms_records = lambda s, body: s._.post(
+        "/TradacomsConnectorRecord/query", json=body
+    ).json()
+    tradacoms_records_more = lambda s, token: s._.post(
+        "/TradacomsConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    x12_records = lambda s, body: s._.post(
+        "/X12ConnectorRecord/query", json=body
+    ).json()
+    x12_records_more = lambda s, token: s._.post(
+        "/X12ConnectorRecord/queryMore", json={"queryToken": token}
+    ).json()
+
+    log = lambda s, exec_id: s._.post(
+        "/ProcessLog",
+        json={"executionId": exec_id, "logLevel": "ALL"},
+    ).json().get("url")
+
+    atom_log = lambda s, body: s._.post("/AtomLog", json=body).json().get("url")
+    as2_artifacts = lambda s, body: s._.post(
+        "/AtomAS2Artifacts", json=body
+    ).json().get("url")
+    worker_log = lambda s, body: s._.post(
+        "/AtomWorkerLog", json=body
+    ).json().get("url")
+
+    audit = lambda s, aid: s._.get(f"/AuditLog/{aid}").json()
+    audit_query = lambda s, body: s._.post("/AuditLog/query", json=body).json()
+    audit_query_more = lambda s, token: s._.post(
+        "/AuditLog/queryMore", json={"queryToken": token}
+    ).json()
+
+    events = lambda s, body: s._.post("/Event/query", json=body).json()
+    events_more = lambda s, token: s._.post(
+        "/Event/queryMore", json={"queryToken": token}
+    ).json()

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -93,7 +93,12 @@ Manages process runs and logs.
 ```python
 class Runs:
     def list(self, body: dict)
+    def list_more(self, token: str)
+    def summary(self, body: dict)
+    def connectors(self, body: dict)
+    def artifacts(self, exec_id: str) -> str
     def log(self, exec_id: str) -> str  # Returns log URL
+    def atom_log(self, body: dict) -> str
 ```
 
 ### Schedules
@@ -164,6 +169,39 @@ class Deployment(BaseModel):
     package_version: Optional[str] = Field(None, alias="packageVersion")
     status: Optional[str] = None
 ```
+
+### ExecutionSummaryRecord
+Represents a summary of a process run.
+
+```python
+class ExecutionSummaryRecord(BaseModel):
+    process_id: str = Field(..., alias="processID")
+    process_name: str = Field(..., alias="processName")
+    status: Optional[str] = None
+```
+
+### ExecutionConnector
+Details about a connector step within an execution.
+
+```python
+class ExecutionConnector(BaseModel):
+    id: str
+    execution_id: str = Field(..., alias="executionId")
+    connector_type: Optional[str] = Field(None, alias="connectorType")
+    success_count: Optional[int] = Field(None, alias="successCount")
+```
+
+### GenericConnectorRecord
+Represents a tracked document in a run.
+
+```python
+class GenericConnectorRecord(BaseModel):
+    id: str
+    execution_id: str = Field(..., alias="executionId")
+    status: Optional[str] = None
+    error_message: Optional[str] = Field(None, alias="errorMessage")
+```
+
 
 ## Exception Classes
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -136,11 +136,46 @@ environments = client.environments.list()
 runs = client.runs.list(body={"query": {...}})
 ```
 
+### More Runs Results
+
+```python
+# Get additional execution records
+more = client.runs.list_more(token="TOKEN")
+```
+
+### Summary Records
+
+```python
+# Query summary records
+summary = client.runs.summary(body={"query": {...}})
+```
+
+### Connector Details
+
+```python
+# Query execution connectors
+connectors = client.runs.connectors(body={"query": {...}})
+```
+
+### Download Artifacts
+
+```python
+# Get download URL for execution artifacts
+url = client.runs.artifacts(exec_id="exec-123")
+```
+
 ### Get Logs
 
 ```python
 # Get execution logs
 log_url = client.runs.log(exec_id="exec-123")
+```
+
+### Atom Log
+
+```python
+# Download atom log
+atom_url = client.runs.atom_log({"atomId": "123", "logDate": "2024-01-01"})
 ```
 
 ## Execute Resource

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,78 @@
+from boomi.models import (
+    ExecutionSummaryRecord,
+    ExecutionConnector,
+    GenericConnectorRecord,
+    AuditLog,
+    Event,
+    ExecutionCountAccount,
+)
+
+
+def parse_model(cls, data):
+    if hasattr(cls, "model_validate"):
+        return cls.model_validate(data)
+    return cls.parse_obj(data)
+
+
+def test_summary_record_aliases():
+    data = {"processID": "p1", "processName": "Proc", "status": "COMPLETE"}
+    rec = parse_model(ExecutionSummaryRecord, data)
+    assert rec.process_id == "p1"
+    assert rec.process_name == "Proc"
+    assert rec.status == "COMPLETE"
+
+
+def test_execution_connector_aliases():
+    data = {
+        "id": "c1",
+        "executionId": "e1",
+        "connectorType": "HTTP",
+        "successCount": 2,
+    }
+    rec = parse_model(ExecutionConnector, data)
+    assert rec.execution_id == "e1"
+    assert rec.connector_type == "HTTP"
+    assert rec.success_count == 2
+
+
+def test_generic_connector_record_aliases():
+    data = {
+        "id": "g1",
+        "executionId": "e1",
+        "status": "OK",
+        "errorMessage": None,
+    }
+    rec = parse_model(GenericConnectorRecord, data)
+    assert rec.id == "g1"
+    assert rec.execution_id == "e1"
+    assert rec.status == "OK"
+
+
+def test_audit_log_aliases():
+    data = {"documentId": "d1", "action": "DOWNLOAD"}
+    log = parse_model(AuditLog, data)
+    assert log.document_id == "d1"
+    assert log.action == "DOWNLOAD"
+
+
+def test_event_aliases():
+    data = {"eventId": "ev1", "eventType": "process.execution", "executionId": "e1"}
+    evt = parse_model(Event, data)
+    assert evt.event_id == "ev1"
+    assert evt.event_type == "process.execution"
+    assert evt.execution_id == "e1"
+
+
+def test_count_account_aliases():
+    data = {
+        "accountId": "a1",
+        "atomId": "atom1",
+        "date": "2024-01-01",
+        "failures": 1,
+        "successes": 2,
+    }
+    cnt = parse_model(ExecutionCountAccount, data)
+    assert cnt.account_id == "a1"
+    assert cnt.atom_id == "atom1"
+    assert cnt.failures == 1
+    assert cnt.successes == 2

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,21 @@
+from boomi.resources.runs import Runs
+from boomi._http import _HTTP
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def test_runs_summary(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    calls = []
+    def fake_post(path, json=None):
+        calls.append((path, json))
+        return DummyResp({"ok": True})
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    result = runs.summary({"q": 1})
+    assert result == {"ok": True}
+    assert calls[0][0] == "/ExecutionSummaryRecord/query"


### PR DESCRIPTION
## Summary
- implement models for execution-related endpoints
- document new execution models in the class reference
- test new model aliases
- test Runs.summary helper

## Testing
- `pytest -q`