### PR TITLE
Ensure folder and deployment resources return typed models

### DIFF
--- a/boomi/resources/deployments.py
+++ b/boomi/resources/deployments.py
@@ -1,7 +1,14 @@
 from .._http import _HTTP
+from ..models.deployment import Deployment
 
 class Deployments:
     def __init__(self, http: _HTTP):
         self._ = http
-    deploy = lambda s, env_id, pkg_id, notes="": s._.post("/DeployedPackage",
-        json={"environmentId": env_id, "packageId": pkg_id, "notes": notes}).json()
+
+    def deploy(self, env_id: str, pkg_id: str, notes: str = "") -> Deployment:
+        payload = {"environmentId": env_id, "packageId": pkg_id, "notes": notes}
+        resp = self._.post("/DeployedPackage", json=payload)
+        data = resp.json()
+        if hasattr(Deployment, "model_validate"):
+            return Deployment.model_validate(data)
+        return Deployment.parse_obj(data)

--- a/boomi/resources/folders.py
+++ b/boomi/resources/folders.py
@@ -1,8 +1,23 @@
 from .._http import _HTTP
+from ..models.folder import Folder
 
 class Folders:
     def __init__(self, http: _HTTP):
         self._ = http
-    create = lambda s, name, parent=None: s._.post("/Folder", json={"name": name, **({"parentId": parent} if parent else {})}).json()
-    get    = lambda s, fid: s._.get(f"/Folder/{fid}").json()
-    delete = lambda s, fid: s._.delete(f"/Folder/{fid}")
+
+    def create(self, name: str, parent: str | None = None) -> Folder:
+        payload = {"name": name, **({"parentId": parent} if parent else {})}
+        resp = self._.post("/Folder", json=payload)
+        data = resp.json()
+        if hasattr(Folder, "model_validate"):
+            return Folder.model_validate(data)
+        return Folder.parse_obj(data)
+
+    def get(self, fid: str) -> Folder:
+        resp = self._.get(f"/Folder/{fid}")
+        data = resp.json()
+        if hasattr(Folder, "model_validate"):
+            return Folder.model_validate(data)
+        return Folder.parse_obj(data)
+
+    delete = lambda self, fid: self._.delete(f"/Folder/{fid}")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,55 @@
+from boomi._http import _HTTP
+from boomi.resources.folders import Folders
+from boomi.resources.deployments import Deployments
+from boomi.models.folder import Folder
+from boomi.models.deployment import Deployment
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def test_folders_return_models(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/Folder"
+        return DummyResp({"folderId": "f1", "name": json["name"]})
+
+    def fake_get(path, **kw):
+        assert path == "/Folder/f1"
+        return DummyResp({"folderId": "f1", "name": "F1"})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    monkeypatch.setattr(http, "get", fake_get)
+
+    folders = Folders(http)
+    folder = folders.create("F1")
+    assert isinstance(folder, Folder)
+    assert folder.id == "f1"
+
+    fetched = folders.get("f1")
+    assert isinstance(fetched, Folder)
+    assert fetched.name == "F1"
+
+
+def test_deployments_return_models(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/DeployedPackage"
+        return DummyResp({
+            "deploymentId": "d1",
+            "componentId": json["packageId"],
+            "environmentId": json["environmentId"],
+        })
+
+    monkeypatch.setattr(http, "post", fake_post)
+
+    deps = Deployments(http)
+    dep = deps.deploy("env", "pkg")
+    assert isinstance(dep, Deployment)
+    assert dep.environment_id == "env"
+


### PR DESCRIPTION
## Summary
- return `Folder` and `Deployment` objects from their respective resources
- add regression tests covering these models

## Testing
- `pytest -q`