### PR TITLE
Return models for process executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ boomi.deployments.deploy(environment_id="DEV_ENV", package_id=pkg["packageId"])
 
 # 3 — trigger run and grab log
 run = boomi.execute.run({"atomId": "DEV_ATOM", "processId": proc.id})
-log = boomi.runs.log(run["executionId"])
+log = boomi.runs.log(run.id)
 print(log[:500])
 ```
 

--- a/boomi/models/__init__.py
+++ b/boomi/models/__init__.py
@@ -1,6 +1,7 @@
 from .component import Component
 from .execution import (
     ExecutionRecord,
+    ExecuteProcessResponse,
     ExecutionSummaryRecord,
     ExecutionConnector,
     GenericConnectorRecord,
@@ -15,6 +16,7 @@ from .deployment import Deployment
 __all__ = [
     "Component",
     "ExecutionRecord",
+    "ExecuteProcessResponse",
     "ExecutionSummaryRecord",
     "ExecutionConnector",
     "GenericConnectorRecord",

--- a/boomi/models/execution.py
+++ b/boomi/models/execution.py
@@ -6,6 +6,10 @@ class ExecutionRecord(BaseModel):
     status: str
     started_at: str
 
+# The response returned by ``/ExecuteProcess`` mirrors ``ExecutionRecord``.
+class ExecuteProcessResponse(ExecutionRecord):
+    pass
+
 class ExecutionSummaryRecord(BaseModel):
     process_id: str = Field(..., alias="processID")
     process_name: str = Field(..., alias="processName")

--- a/boomi/resources/execute.py
+++ b/boomi/resources/execute.py
@@ -1,7 +1,15 @@
 from .._http import _HTTP
+from ..models import ExecuteProcessResponse
 
 class Execute:
     def __init__(self, http: _HTTP):
         self._ = http
-    run    = lambda s, body: s._.post("/ExecuteProcess", json=body).json()
+
+    def run(self, body: dict) -> ExecuteProcessResponse:
+        resp = self._.post("/ExecuteProcess", json=body)
+        data = resp.json()
+        if hasattr(ExecuteProcessResponse, "model_validate"):
+            return ExecuteProcessResponse.model_validate(data)
+        return ExecuteProcessResponse.parse_obj(data)
+
     cancel = lambda s, exec_id: s._.get(f"/CancelExecution?executionId={exec_id}")

--- a/boomi/resources/runs.py
+++ b/boomi/resources/runs.py
@@ -1,20 +1,47 @@
 from .._http import _HTTP
+from ..models import ExecutionRecord, ExecutionSummaryRecord
 
 class Runs:
     def __init__(self, http: _HTTP):
         self._ = http
 
-    list = lambda s, body: s._.post("/ExecutionRecord/query", json=body).json()
-    list_more = lambda s, token: s._.post(
-        "/ExecutionRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def list(self, body: dict, *, parse: bool = True):
+        data = self._.post("/ExecutionRecord/query", json=body).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionRecord, "model_validate"):
+            return [ExecutionRecord.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
 
-    summary = lambda s, body: s._.post(
-        "/ExecutionSummaryRecord/query", json=body
-    ).json()
-    summary_more = lambda s, token: s._.post(
-        "/ExecutionSummaryRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def list_more(self, token: str, *, parse: bool = True):
+        data = self._.post(
+            "/ExecutionRecord/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionRecord, "model_validate"):
+            return [ExecutionRecord.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
+
+    def summary(self, body: dict, *, parse: bool = True):
+        data = self._.post(
+            "/ExecutionSummaryRecord/query", json=body
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionSummaryRecord, "model_validate"):
+            return [ExecutionSummaryRecord.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
+
+    def summary_more(self, token: str, *, parse: bool = True):
+        data = self._.post(
+            "/ExecutionSummaryRecord/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionSummaryRecord, "model_validate"):
+            return [ExecutionSummaryRecord.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
 
     connectors = lambda s, body: s._.post(
         "/ExecutionConnector/query", json=body

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,34 @@
+from boomi._http import _HTTP
+from boomi.resources.execute import Execute
+from boomi.resources.runs import Runs
+from boomi.models import ExecuteProcessResponse, ExecutionRecord, ExecutionSummaryRecord
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+def test_execute_run_returns_model(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "post", lambda path, json=None: DummyResp({"executionId": "e1", "status": "OK", "started_at": "now"}))
+    execute = Execute(http)
+    result = execute.run({"processId": "p"})
+    assert isinstance(result, ExecuteProcessResponse)
+    assert result.id == "e1"
+
+
+def test_runs_list_parses(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "post", lambda path, json=None: DummyResp({"result": [{"executionId": "e1", "status": "OK", "started_at": "t"}]}))
+    runs = Runs(http)
+    items = runs.list({"q": 1})
+    assert len(items) == 1 and isinstance(items[0], ExecutionRecord)
+
+
+def test_runs_summary_parses(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "post", lambda path, json=None: DummyResp({"result": [{"processID": "p1", "processName": "Proc"}]}))
+    runs = Runs(http)
+    items = runs.summary({"q": 1})
+    assert len(items) == 1 and isinstance(items[0], ExecutionSummaryRecord)

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -11,11 +11,13 @@ class DummyResp:
 def test_runs_summary(monkeypatch):
     http = _HTTP("base", ("u", "p"))
     calls = []
+
     def fake_post(path, json=None):
         calls.append((path, json))
         return DummyResp({"ok": True})
+
     monkeypatch.setattr(http, "post", fake_post)
     runs = Runs(http)
-    result = runs.summary({"q": 1})
+    result = runs.summary({"q": 1}, parse=False)
     assert result == {"ok": True}
     assert calls[0][0] == "/ExecutionSummaryRecord/query"


### PR DESCRIPTION
## Summary
- add `ExecuteProcessResponse` model and export
- `Execute.run` now returns an `ExecuteProcessResponse` instance
- optionally parse `/ExecutionRecord` and `/ExecutionSummaryRecord` queries
- update quick start snippet
- regression tests for execute and runs resources

## Testing
- `pytest -q`