### PR TITLE
Refactor run helpers and expand models

### DIFF
--- a/boomi/models/execution.py
+++ b/boomi/models/execution.py
@@ -3,8 +3,30 @@ from typing import Optional
 
 class ExecutionRecord(BaseModel):
     id: str = Field(..., alias="executionId")
-    status: str
-    execution_time: str = Field(..., alias="executionTime")
+    status: Optional[str] = None
+    execution_time: Optional[str] = Field(None, alias="executionTime")
+    process_id: Optional[str] = Field(None, alias="processId")
+    process_name: Optional[str] = Field(None, alias="processName")
+    atom_id: Optional[str] = Field(None, alias="atomId")
+    atom_name: Optional[str] = Field(None, alias="atomName")
+    account: Optional[str] = None
+    message: Optional[str] = None
+    report_key: Optional[str] = Field(None, alias="reportKey")
+    recorded_date: Optional[str] = Field(None, alias="recordedDate")
+    execution_type: Optional[str] = Field(None, alias="executionType")
+    execution_duration: Optional[int] = Field(None, alias="executionDuration")
+    inbound_document_count: Optional[int] = Field(None, alias="inboundDocumentCount")
+    outbound_document_count: Optional[int] = Field(None, alias="outboundDocumentCount")
+    inbound_document_size: Optional[int] = Field(None, alias="inboundDocumentSize")
+    outbound_document_size: Optional[int] = Field(None, alias="outboundDocumentSize")
+    inbound_error_document_count: Optional[int] = Field(
+        None, alias="inboundErrorDocumentCount"
+    )
+    launcher_id: Optional[str] = Field(None, alias="launcherID")
+    node_id: Optional[str] = Field(None, alias="nodeId")
+    original_execution_id: Optional[str] = Field(None, alias="originalExecutionId")
+    parent_execution_id: Optional[str] = Field(None, alias="parentExecutionId")
+    top_level_execution_id: Optional[str] = Field(None, alias="topLevelExecutionId")
 
 # The response returned by ``/ExecuteProcess`` mirrors ``ExecutionRecord``.
 class ExecuteProcessResponse(ExecutionRecord):

--- a/boomi/resources/atoms.py
+++ b/boomi/resources/atoms.py
@@ -2,5 +2,7 @@ from .._http import _HTTP
 
 class Atoms:
     def __init__(self, http: _HTTP):
-        self._ = http
-    list = lambda s: s._.get("/Atom").json()
+        self._http = http
+
+    def list(self):
+        return self._http.get("/Atom").json()

--- a/boomi/resources/components.py
+++ b/boomi/resources/components.py
@@ -28,7 +28,15 @@ class Components:
         r = self._http.get(f"/Component/{cid}", headers=_HDR_XML)
         return Component.model_validate(self._attrs(r.content))
 
-    update = lambda self, cid, xml: self._http.post(
-        f"/Component/{cid}", data=xml.encode(), headers=_HDR_XML
-    )
-    delete = lambda self, cid: self._http.delete(f"/Component/{cid}")
+    def update(self, cid: str, xml: Union[str, Path, BinaryIO]) -> Component:
+        xml_bytes = (
+            xml.encode() if isinstance(xml, str)
+            else xml.read_bytes() if isinstance(xml, Path)
+            else xml.read()
+        )
+        r = self._http.post(f"/Component/{cid}", data=xml_bytes, headers=_HDR_XML)
+        return Component.model_validate(self._attrs(r.content))
+
+    def delete(self, cid: str) -> bool:
+        self._http.delete(f"/Component/{cid}")
+        return True

--- a/boomi/resources/deployments.py
+++ b/boomi/resources/deployments.py
@@ -3,11 +3,11 @@ from ..models.deployment import Deployment
 
 class Deployments:
     def __init__(self, http: _HTTP):
-        self._ = http
+        self._http = http
 
     def deploy(self, env_id: str, pkg_id: str, notes: str = "") -> Deployment:
         payload = {"environmentId": env_id, "packageId": pkg_id, "notes": notes}
-        resp = self._.post("/DeployedPackage", json=payload)
+        resp = self._http.post("/DeployedPackage", json=payload)
         data = resp.json()
         if hasattr(Deployment, "model_validate"):
             return Deployment.model_validate(data)

--- a/boomi/resources/environments.py
+++ b/boomi/resources/environments.py
@@ -1,5 +1,8 @@
 from .._http import _HTTP
 
 class Environments:
-    def __init__(self, http: _HTTP): self._ = http
-    list = lambda s: s._.get("/Environment").json()
+    def __init__(self, http: _HTTP):
+        self._http = http
+
+    def list(self):
+        return self._http.get("/Environment").json()

--- a/boomi/resources/execute.py
+++ b/boomi/resources/execute.py
@@ -3,13 +3,15 @@ from ..models import ExecuteProcessResponse
 
 class Execute:
     def __init__(self, http: _HTTP):
-        self._ = http
+        self._http = http
 
     def run(self, body: dict) -> ExecuteProcessResponse:
-        resp = self._.post("/ExecuteProcess", json=body)
+        resp = self._http.post("/ExecuteProcess", json=body)
         data = resp.json()
         if hasattr(ExecuteProcessResponse, "model_validate"):
             return ExecuteProcessResponse.model_validate(data)
         return ExecuteProcessResponse.parse_obj(data)
 
-    cancel = lambda s, exec_id: s._.get(f"/CancelExecution?executionId={exec_id}")
+    def cancel(self, exec_id: str) -> bool:
+        self._http.get(f"/CancelExecution?executionId={exec_id}")
+        return True

--- a/boomi/resources/extensions.py
+++ b/boomi/resources/extensions.py
@@ -2,12 +2,18 @@ from .._http import _HTTP
 
 class Extensions:
     def __init__(self, http: _HTTP):
-        self._ = http
-    get    = lambda s, env: s._.get(f"/EnvironmentExtensions/{env}").json()
-    update = lambda s, env, body: s._.post(f"/EnvironmentExtensions/{env}", json=body).json()
-    query  = lambda s, body: s._.post("/EnvironmentExtensions/query", json=body).json()
-    query_conn_field_summary = (
-        lambda s, body: s._.post(
+        self._http = http
+
+    def get(self, env):
+        return self._http.get(f"/EnvironmentExtensions/{env}").json()
+
+    def update(self, env, body):
+        return self._http.post(f"/EnvironmentExtensions/{env}", json=body).json()
+
+    def query(self, body):
+        return self._http.post("/EnvironmentExtensions/query", json=body).json()
+
+    def query_conn_field_summary(self, body):
+        return self._http.post(
             "/EnvironmentConnectionFieldExtensionSummary/query", json=body
         ).json()
-    )

--- a/boomi/resources/folders.py
+++ b/boomi/resources/folders.py
@@ -4,21 +4,23 @@ from typing import Optional
 
 class Folders:
     def __init__(self, http: _HTTP):
-        self._ = http
+        self._http = http
 
     def create(self, name: str, parent: Optional[str] = None) -> Folder:
         payload = {"name": name, **({"parentId": parent} if parent else {})}
-        resp = self._.post("/Folder", json=payload)
+        resp = self._http.post("/Folder", json=payload)
         data = resp.json()
         if hasattr(Folder, "model_validate"):
             return Folder.model_validate(data)
         return Folder.parse_obj(data)
 
     def get(self, fid: str) -> Folder:
-        resp = self._.get(f"/Folder/{fid}")
+        resp = self._http.get(f"/Folder/{fid}")
         data = resp.json()
         if hasattr(Folder, "model_validate"):
             return Folder.model_validate(data)
         return Folder.parse_obj(data)
 
-    delete = lambda self, fid: self._.delete(f"/Folder/{fid}")
+    def delete(self, fid: str) -> bool:
+        self._http.delete(f"/Folder/{fid}")
+        return True

--- a/boomi/resources/packages.py
+++ b/boomi/resources/packages.py
@@ -2,6 +2,12 @@ from .._http import _HTTP
 
 class Packages:
     def __init__(self, http: _HTTP):
-        self._ = http
-    create = lambda s, cid, ver=None, notes=None: s._.post("/PackagedComponent",
-        json={"componentId": cid, **({"packageVersion": ver} if ver else {}), **({"notes": notes} if notes else {})}).json()
+        self._http = http
+
+    def create(self, cid, ver=None, notes=None):
+        payload = {"componentId": cid}
+        if ver:
+            payload["packageVersion"] = ver
+        if notes:
+            payload["notes"] = notes
+        return self._http.post("/PackagedComponent", json=payload).json()

--- a/boomi/resources/runs.py
+++ b/boomi/resources/runs.py
@@ -1,12 +1,21 @@
 from .._http import _HTTP
-from ..models import ExecutionRecord, ExecutionSummaryRecord
+from ..models import (
+    ExecutionRecord,
+    ExecutionSummaryRecord,
+    ExecutionConnector,
+    GenericConnectorRecord,
+    ExecutionCountAccount,
+    ExecutionCountAccountGroup,
+    AuditLog,
+    Event,
+)
 
 class Runs:
     def __init__(self, http: _HTTP):
-        self._ = http
+        self._http = http
 
     def list(self, body: dict, *, parse: bool = True):
-        data = self._.post("/ExecutionRecord/query", json=body).json()
+        data = self._http.post("/ExecutionRecord/query", json=body).json()
         if not parse:
             return data
         if hasattr(ExecutionRecord, "model_validate"):
@@ -14,7 +23,7 @@ class Runs:
         return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
 
     def list_more(self, token: str, *, parse: bool = True):
-        data = self._.post(
+        data = self._http.post(
             "/ExecutionRecord/queryMore", json={"queryToken": token}
         ).json()
         if not parse:
@@ -24,7 +33,7 @@ class Runs:
         return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
 
     def summary(self, body: dict, *, parse: bool = True):
-        data = self._.post(
+        data = self._http.post(
             "/ExecutionSummaryRecord/query", json=body
         ).json()
         if not parse:
@@ -34,7 +43,7 @@ class Runs:
         return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
 
     def summary_more(self, token: str, *, parse: bool = True):
-        data = self._.post(
+        data = self._http.post(
             "/ExecutionSummaryRecord/queryMore", json={"queryToken": token}
         ).json()
         if not parse:
@@ -43,124 +52,225 @@ class Runs:
             return [ExecutionSummaryRecord.model_validate(r) for r in data.get("result", [])]
         return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
 
-    connectors = lambda s, body: s._.post(
-        "/ExecutionConnector/query", json=body
-    ).json()
-    connectors_more = lambda s, token: s._.post(
-        "/ExecutionConnector/queryMore", json={"queryToken": token}
-    ).json()
+    def connectors(self, body: dict, *, parse: bool = True):
+        data = self._http.post("/ExecutionConnector/query", json=body).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionConnector, "model_validate"):
+            return [ExecutionConnector.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionConnector.parse_obj(r) for r in data.get("result", [])]
 
-    count_account = lambda s, body: s._.post(
-        "/ExecutionCountAccount/query", json=body
-    ).json()
-    count_account_more = lambda s, token: s._.post(
-        "/ExecutionCountAccount/queryMore", json={"queryToken": token}
-    ).json()
+    def connectors_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/ExecutionConnector/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionConnector, "model_validate"):
+            return [ExecutionConnector.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionConnector.parse_obj(r) for r in data.get("result", [])]
 
-    count_group = lambda s, body: s._.post(
-        "/ExecutionCountAccountGroup/query", json=body
-    ).json()
-    count_group_more = lambda s, token: s._.post(
-        "/ExecutionCountAccountGroup/queryMore", json={"queryToken": token}
-    ).json()
+    def count_account(self, body: dict, *, parse: bool = True):
+        data = self._http.post("/ExecutionCountAccount/query", json=body).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionCountAccount, "model_validate"):
+            return [ExecutionCountAccount.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionCountAccount.parse_obj(r) for r in data.get("result", [])]
 
-    artifacts = lambda s, exec_id: s._.post(
-        "/ExecutionArtifacts", json={"executionId": exec_id}
-    ).json().get("url")
+    def count_account_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/ExecutionCountAccount/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionCountAccount, "model_validate"):
+            return [ExecutionCountAccount.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionCountAccount.parse_obj(r) for r in data.get("result", [])]
 
-    request = lambda s, body: s._.post("/ExecutionRequest", json=body).json()
+    def count_group(self, body: dict, *, parse: bool = True):
+        data = self._http.post(
+            "/ExecutionCountAccountGroup/query", json=body
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionCountAccountGroup, "model_validate"):
+            return [ExecutionCountAccountGroup.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionCountAccountGroup.parse_obj(r) for r in data.get("result", [])]
 
-    doc = lambda s, gid: s._.get(f"/GenericConnectorRecord/{gid}").json()
-    docs = lambda s, body: s._.post(
-        "/GenericConnectorRecord/query", json=body
-    ).json()
-    docs_more = lambda s, token: s._.post(
-        "/GenericConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def count_group_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/ExecutionCountAccountGroup/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(ExecutionCountAccountGroup, "model_validate"):
+            return [ExecutionCountAccountGroup.model_validate(r) for r in data.get("result", [])]
+        return [ExecutionCountAccountGroup.parse_obj(r) for r in data.get("result", [])]
 
-    as2_records = lambda s, body: s._.post(
-        "/AS2ConnectorRecord/query", json=body
-    ).json()
-    as2_records_more = lambda s, token: s._.post(
-        "/AS2ConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def artifacts(self, exec_id: str) -> str:
+        return (
+            self._http.post("/ExecutionArtifacts", json={"executionId": exec_id})
+            .json()
+            .get("url")
+        )
 
-    edicustom_records = lambda s, body: s._.post(
-        "/EdiCustomConnectorRecord/query", json=body
-    ).json()
-    edicustom_records_more = lambda s, token: s._.post(
-        "/EdiCustomConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def request(self, body: dict):
+        return self._http.post("/ExecutionRequest", json=body).json()
 
-    edifact_records = lambda s, body: s._.post(
-        "/EDIFACTConnectorRecord/query", json=body
-    ).json()
-    edifact_records_more = lambda s, token: s._.post(
-        "/EDIFACTConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def doc(self, gid: str, *, parse: bool = True):
+        data = self._http.get(f"/GenericConnectorRecord/{gid}").json()
+        if not parse:
+            return data
+        if hasattr(GenericConnectorRecord, "model_validate"):
+            return GenericConnectorRecord.model_validate(data)
+        return GenericConnectorRecord.parse_obj(data)
 
-    hl7_records = lambda s, body: s._.post(
-        "/HL7ConnectorRecord/query", json=body
-    ).json()
-    hl7_records_more = lambda s, token: s._.post(
-        "/HL7ConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def docs(self, body: dict, *, parse: bool = True):
+        data = self._http.post("/GenericConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        if hasattr(GenericConnectorRecord, "model_validate"):
+            return [GenericConnectorRecord.model_validate(r) for r in data.get("result", [])]
+        return [GenericConnectorRecord.parse_obj(r) for r in data.get("result", [])]
 
-    odette_records = lambda s, body: s._.post(
-        "/ODETTEConnectorRecord/query", json=body
-    ).json()
-    odette_records_more = lambda s, token: s._.post(
-        "/ODETTEConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def docs_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/GenericConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        if hasattr(GenericConnectorRecord, "model_validate"):
+            return [GenericConnectorRecord.model_validate(r) for r in data.get("result", [])]
+        return [GenericConnectorRecord.parse_obj(r) for r in data.get("result", [])]
 
-    oftp2_records = lambda s, body: s._.post(
-        "/OFTP2ConnectorRecord/query", json=body
-    ).json()
-    oftp2_records_more = lambda s, token: s._.post(
-        "/OFTP2ConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def as2_records(self, body: dict):
+        return self._http.post("/AS2ConnectorRecord/query", json=body).json()
 
-    rosetta_records = lambda s, body: s._.post(
-        "/RosettaNetConnectorRecord/query", json=body
-    ).json()
-    rosetta_records_more = lambda s, token: s._.post(
-        "/RosettaNetConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def as2_records_more(self, token: str):
+        return self._http.post(
+            "/AS2ConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
 
-    tradacoms_records = lambda s, body: s._.post(
-        "/TradacomsConnectorRecord/query", json=body
-    ).json()
-    tradacoms_records_more = lambda s, token: s._.post(
-        "/TradacomsConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def edicustom_records(self, body: dict):
+        return self._http.post("/EdiCustomConnectorRecord/query", json=body).json()
 
-    x12_records = lambda s, body: s._.post(
-        "/X12ConnectorRecord/query", json=body
-    ).json()
-    x12_records_more = lambda s, token: s._.post(
-        "/X12ConnectorRecord/queryMore", json={"queryToken": token}
-    ).json()
+    def edicustom_records_more(self, token: str):
+        return self._http.post(
+            "/EdiCustomConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
 
-    log = lambda s, exec_id: s._.post(
-        "/ProcessLog",
-        json={"executionId": exec_id, "logLevel": "ALL"},
-    ).json().get("url")
+    def edifact_records(self, body: dict):
+        return self._http.post("/EDIFACTConnectorRecord/query", json=body).json()
 
-    atom_log = lambda s, body: s._.post("/AtomLog", json=body).json().get("url")
-    as2_artifacts = lambda s, body: s._.post(
-        "/AtomAS2Artifacts", json=body
-    ).json().get("url")
-    worker_log = lambda s, body: s._.post(
-        "/AtomWorkerLog", json=body
-    ).json().get("url")
+    def edifact_records_more(self, token: str):
+        return self._http.post(
+            "/EDIFACTConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
 
-    audit = lambda s, aid: s._.get(f"/AuditLog/{aid}").json()
-    audit_query = lambda s, body: s._.post("/AuditLog/query", json=body).json()
-    audit_query_more = lambda s, token: s._.post(
-        "/AuditLog/queryMore", json={"queryToken": token}
-    ).json()
+    def hl7_records(self, body: dict):
+        return self._http.post("/HL7ConnectorRecord/query", json=body).json()
 
-    events = lambda s, body: s._.post("/Event/query", json=body).json()
-    events_more = lambda s, token: s._.post(
-        "/Event/queryMore", json={"queryToken": token}
-    ).json()
+    def hl7_records_more(self, token: str):
+        return self._http.post(
+            "/HL7ConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def odette_records(self, body: dict):
+        return self._http.post("/ODETTEConnectorRecord/query", json=body).json()
+
+    def odette_records_more(self, token: str):
+        return self._http.post(
+            "/ODETTEConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def oftp2_records(self, body: dict):
+        return self._http.post("/OFTP2ConnectorRecord/query", json=body).json()
+
+    def oftp2_records_more(self, token: str):
+        return self._http.post(
+            "/OFTP2ConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def rosetta_records(self, body: dict):
+        return self._http.post("/RosettaNetConnectorRecord/query", json=body).json()
+
+    def rosetta_records_more(self, token: str):
+        return self._http.post(
+            "/RosettaNetConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def tradacoms_records(self, body: dict):
+        return self._http.post("/TradacomsConnectorRecord/query", json=body).json()
+
+    def tradacoms_records_more(self, token: str):
+        return self._http.post(
+            "/TradacomsConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def x12_records(self, body: dict):
+        return self._http.post("/X12ConnectorRecord/query", json=body).json()
+
+    def x12_records_more(self, token: str):
+        return self._http.post(
+            "/X12ConnectorRecord/queryMore", json={"queryToken": token}
+        ).json()
+
+    def log(self, exec_id: str) -> str:
+        return (
+            self._http.post(
+                "/ProcessLog", json={"executionId": exec_id, "logLevel": "ALL"}
+            )
+            .json()
+            .get("url")
+        )
+
+    def get_log_content(self, exec_id: str) -> str:
+        url = self.log(exec_id)
+        import requests
+
+        resp = requests.get(url, auth=self._http.auth, timeout=self._http.timeout)
+        return resp.text
+
+    def atom_log(self, body: dict) -> str:
+        return self._http.post("/AtomLog", json=body).json().get("url")
+
+    def as2_artifacts(self, body: dict) -> str:
+        return self._http.post("/AtomAS2Artifacts", json=body).json().get("url")
+
+    def worker_log(self, body: dict) -> str:
+        return self._http.post("/AtomWorkerLog", json=body).json().get("url")
+
+    def audit(self, aid: str, *, parse: bool = True):
+        data = self._http.get(f"/AuditLog/{aid}").json()
+        if not parse:
+            return data
+        return AuditLog.model_validate(data)
+
+    def audit_query(self, body: dict, *, parse: bool = True):
+        data = self._http.post("/AuditLog/query", json=body).json()
+        if not parse:
+            return data
+        return [AuditLog.model_validate(r) for r in data.get("result", [])]
+
+    def audit_query_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/AuditLog/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        return [AuditLog.model_validate(r) for r in data.get("result", [])]
+
+    def events(self, body: dict, *, parse: bool = True):
+        data = self._http.post("/Event/query", json=body).json()
+        if not parse:
+            return data
+        return [Event.model_validate(r) for r in data.get("result", [])]
+
+    def events_more(self, token: str, *, parse: bool = True):
+        data = self._http.post(
+            "/Event/queryMore", json={"queryToken": token}
+        ).json()
+        if not parse:
+            return data
+        return [Event.model_validate(r) for r in data.get("result", [])]

--- a/boomi/resources/runtime_release.py
+++ b/boomi/resources/runtime_release.py
@@ -2,9 +2,19 @@ from .._http import _HTTP
 
 class RuntimeRelease:
     _P = "/RuntimeReleaseSchedule"
+
     def __init__(self, http: _HTTP):
-        self._ = http
-    create = lambda s, body: s._.post(s._P, json=body).json()
-    get    = lambda s, cid: s._.get(f"{s._P}/{cid}").json()
-    update = lambda s, cid, body: s._.post(f"{s._P}/{cid}", json=body).json()
-    delete = lambda s, cid: s._.delete(f"{s._P}/{cid}")
+        self._http = http
+
+    def create(self, body):
+        return self._http.post(self._P, json=body).json()
+
+    def get(self, cid):
+        return self._http.get(f"{self._P}/{cid}").json()
+
+    def update(self, cid, body):
+        return self._http.post(f"{self._P}/{cid}", json=body).json()
+
+    def delete(self, cid):
+        self._http.delete(f"{self._P}/{cid}")
+        return True

--- a/boomi/resources/schedules.py
+++ b/boomi/resources/schedules.py
@@ -3,11 +3,19 @@ from .._http import _HTTP
 
 class Schedules:
     _PATH = "/ProcessSchedules"
+
     def __init__(self, http: _HTTP):
-        self._ = http
-    get    = lambda s, sid: s._.get(f"{s._PATH}/{sid}").json()
-    update = lambda s, sid, body: s._.post(f"{s._PATH}/{sid}", json=body).json()
-    query  = lambda s, body: s._.post(f"{s._PATH}/query", json=body).json()
+        self._http = http
+
+    def get(self, sid):
+        return self._http.get(f"{self._PATH}/{sid}").json()
+
+    def update(self, sid, body):
+        return self._http.post(f"{self._PATH}/{sid}", json=body).json()
+
+    def query(self, body):
+        return self._http.post(f"{self._PATH}/query", json=body).json()
+
     def bulk(self, ids: List[str]) -> Dict[str, Any]:
         req = {"request": [{"id": i} for i in ids]}
-        return self._.post(f"{self._PATH}/bulk", json=req).json()
+        return self._http.post(f"{self._PATH}/bulk", json=req).json()

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -153,7 +153,7 @@ summary = client.runs.summary(body={"query": {...}})
 ### Connector Details
 
 ```python
-# Query execution connectors
+# Query execution connectors as model objects
 connectors = client.runs.connectors(body={"query": {...}})
 ```
 
@@ -169,6 +169,7 @@ url = client.runs.artifacts(exec_id="exec-123")
 ```python
 # Get execution logs
 log_url = client.runs.log(exec_id="exec-123")
+# log_url is a download link. Use get_log_content() to fetch the text
 ```
 
 ### Atom Log

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -82,3 +82,59 @@ def test_runs_summary_parses(monkeypatch):
     runs = Runs(http)
     items = runs.summary({"q": 1})
     assert len(items) == 1 and isinstance(items[0], ExecutionSummaryRecord)
+
+
+def test_runs_list_more(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/ExecutionRecord/queryMore"
+        return DummyResp({"result": [{"executionId": "e2", "status": "OK", "executionTime": "t2"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+
+    runs = Runs(http)
+    items = runs.list_more("tok")
+    assert len(items) == 1 and items[0].id == "e2"
+
+
+def test_runs_summary_more(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/ExecutionSummaryRecord/queryMore"
+        return DummyResp({"result": [{"processID": "p2", "processName": "P"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    items = runs.summary_more("tok")
+    assert len(items) == 1 and items[0].process_id == "p2"
+
+
+def test_connectors_parse(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/ExecutionConnector/query"
+        return DummyResp({"result": [{"id": "c1", "executionId": "e"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    items = runs.connectors({})
+    assert len(items) == 1 and items[0].id == "c1"
+    raw = runs.connectors({}, parse=False)
+    assert raw["result"][0]["id"] == "c1"
+
+
+def test_log_url(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "post", lambda path, json=None: DummyResp({"url": "http://x"}))
+    runs = Runs(http)
+    assert runs.log("e1") == "http://x"
+
+
+def test_execute_cancel(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "get", lambda path: DummyResp({}))
+    execute = Execute(http)
+    assert execute.cancel("e1") is True


### PR DESCRIPTION
## Summary
- map full ExecutionRecord fields
- refactor resource helpers into normal functions
- parse connector and audit queries into models
- standardize `_http` attribute usage
- add convenience log content helper
- adjust docs
- extend tests for run helpers and execute cancel

## Testing
- `pytest -q`