### PR TITLE
Improve run helpers and add pagination

### DIFF
--- a/boomi/_http.py
+++ b/boomi/_http.py
@@ -104,7 +104,10 @@ class _HTTP:
 
     def delete(self, path: str, **kw):
         kw.setdefault("headers", self.h_json)
-        return self._request("DELETE", path, **kw)
+        resp = self._request("DELETE", path, **kw)
+        if resp.status_code == 204:
+            return True
+        return self.as_dict(resp)
 
     # ------------------------------------------------------------------ #
     # transparent pagination for /query + /queryMore

--- a/boomi/resources/components.py
+++ b/boomi/resources/components.py
@@ -16,6 +16,7 @@ class Components:
 
     # public
     def create(self, xml: Union[str, Path, BinaryIO]) -> Component:
+        """Create a component from XML content."""
         xml_bytes = (
             xml.encode() if isinstance(xml, str)
             else xml.read_bytes() if isinstance(xml, Path)
@@ -25,10 +26,12 @@ class Components:
         return Component.model_validate(self._attrs(r.content))
 
     def get(self, cid: str) -> Component:
+        """Retrieve component details by id."""
         r = self._http.get(f"/Component/{cid}", headers=_HDR_XML)
         return Component.model_validate(self._attrs(r.content))
 
     def update(self, cid: str, xml: Union[str, Path, BinaryIO]) -> Component:
+        """Update a component with new XML content."""
         xml_bytes = (
             xml.encode() if isinstance(xml, str)
             else xml.read_bytes() if isinstance(xml, Path)
@@ -38,5 +41,6 @@ class Components:
         return Component.model_validate(self._attrs(r.content))
 
     def delete(self, cid: str) -> bool:
+        """Delete a component."""
         self._http.delete(f"/Component/{cid}")
         return True

--- a/boomi/resources/deployments.py
+++ b/boomi/resources/deployments.py
@@ -6,6 +6,7 @@ class Deployments:
         self._http = http
 
     def deploy(self, env_id: str, pkg_id: str, notes: str = "") -> Deployment:
+        """Deploy a package to an environment."""
         payload = {"environmentId": env_id, "packageId": pkg_id, "notes": notes}
         resp = self._http.post("/DeployedPackage", json=payload)
         data = resp.json()

--- a/boomi/resources/execute.py
+++ b/boomi/resources/execute.py
@@ -6,6 +6,7 @@ class Execute:
         self._http = http
 
     def run(self, body: dict) -> ExecuteProcessResponse:
+        """Execute a process and return the execution metadata."""
         resp = self._http.post("/ExecuteProcess", json=body)
         data = resp.json()
         if hasattr(ExecuteProcessResponse, "model_validate"):
@@ -13,5 +14,6 @@ class Execute:
         return ExecuteProcessResponse.parse_obj(data)
 
     def cancel(self, exec_id: str) -> bool:
+        """Cancel a running execution."""
         self._http.get(f"/CancelExecution?executionId={exec_id}")
         return True

--- a/boomi/resources/folders.py
+++ b/boomi/resources/folders.py
@@ -7,6 +7,7 @@ class Folders:
         self._http = http
 
     def create(self, name: str, parent: Optional[str] = None) -> Folder:
+        """Create a folder optionally under ``parent``."""
         payload = {"name": name, **({"parentId": parent} if parent else {})}
         resp = self._http.post("/Folder", json=payload)
         data = resp.json()
@@ -15,6 +16,7 @@ class Folders:
         return Folder.parse_obj(data)
 
     def get(self, fid: str) -> Folder:
+        """Retrieve folder details by id."""
         resp = self._http.get(f"/Folder/{fid}")
         data = resp.json()
         if hasattr(Folder, "model_validate"):
@@ -22,5 +24,6 @@ class Folders:
         return Folder.parse_obj(data)
 
     def delete(self, fid: str) -> bool:
+        """Delete a folder."""
         self._http.delete(f"/Folder/{fid}")
         return True

--- a/boomi/resources/runs.py
+++ b/boomi/resources/runs.py
@@ -1,4 +1,5 @@
 from .._http import _HTTP
+from ..utils import paginate_query
 from ..models import (
     ExecutionRecord,
     ExecutionSummaryRecord,
@@ -10,11 +11,18 @@ from ..models import (
     Event,
 )
 
+_GENERIC_PARSER = (
+    GenericConnectorRecord.model_validate
+    if hasattr(GenericConnectorRecord, "model_validate")
+    else GenericConnectorRecord.parse_obj
+)
+
 class Runs:
     def __init__(self, http: _HTTP):
         self._http = http
 
     def list(self, body: dict, *, parse: bool = True):
+        """Query execution records."""
         data = self._http.post("/ExecutionRecord/query", json=body).json()
         if not parse:
             return data
@@ -23,6 +31,7 @@ class Runs:
         return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
 
     def list_more(self, token: str, *, parse: bool = True):
+        """Continue a record query using ``queryToken``."""
         data = self._http.post(
             "/ExecutionRecord/queryMore", json={"queryToken": token}
         ).json()
@@ -33,6 +42,7 @@ class Runs:
         return [ExecutionRecord.parse_obj(r) for r in data.get("result", [])]
 
     def summary(self, body: dict, *, parse: bool = True):
+        """Query execution summary records."""
         data = self._http.post(
             "/ExecutionSummaryRecord/query", json=body
         ).json()
@@ -42,7 +52,24 @@ class Runs:
             return [ExecutionSummaryRecord.model_validate(r) for r in data.get("result", [])]
         return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
 
+    def list_all(self, body: dict, *, parse: bool = True):
+        """Yield all execution records for ``body`` handling pagination."""
+        def first_call(payload: dict):
+            return self._http.post("/ExecutionRecord/query", json=payload).json()
+
+        def more_call(tok: str):
+            return self._http.post("/ExecutionRecord/queryMore", json={"queryToken": tok}).json()
+
+        parser = (
+            ExecutionRecord.model_validate
+            if hasattr(ExecutionRecord, "model_validate")
+            else ExecutionRecord.parse_obj
+        )
+
+        yield from paginate_query(first_call, more_call, body, parse_item=parser, parse=parse)
+
     def summary_more(self, token: str, *, parse: bool = True):
+        """Continue a summary query using ``queryToken``."""
         data = self._http.post(
             "/ExecutionSummaryRecord/queryMore", json={"queryToken": token}
         ).json()
@@ -52,7 +79,24 @@ class Runs:
             return [ExecutionSummaryRecord.model_validate(r) for r in data.get("result", [])]
         return [ExecutionSummaryRecord.parse_obj(r) for r in data.get("result", [])]
 
+    def summary_all(self, body: dict, *, parse: bool = True):
+        """Yield all execution summary records for ``body`` handling pagination."""
+        def first_call(payload: dict):
+            return self._http.post("/ExecutionSummaryRecord/query", json=payload).json()
+
+        def more_call(tok: str):
+            return self._http.post("/ExecutionSummaryRecord/queryMore", json={"queryToken": tok}).json()
+
+        parser = (
+            ExecutionSummaryRecord.model_validate
+            if hasattr(ExecutionSummaryRecord, "model_validate")
+            else ExecutionSummaryRecord.parse_obj
+        )
+
+        yield from paginate_query(first_call, more_call, body, parse_item=parser, parse=parse)
+
     def connectors(self, body: dict, *, parse: bool = True):
+        """Query execution connector records."""
         data = self._http.post("/ExecutionConnector/query", json=body).json()
         if not parse:
             return data
@@ -61,6 +105,7 @@ class Runs:
         return [ExecutionConnector.parse_obj(r) for r in data.get("result", [])]
 
     def connectors_more(self, token: str, *, parse: bool = True):
+        """Fetch additional connector results via ``queryToken``."""
         data = self._http.post(
             "/ExecutionConnector/queryMore", json={"queryToken": token}
         ).json()
@@ -71,6 +116,7 @@ class Runs:
         return [ExecutionConnector.parse_obj(r) for r in data.get("result", [])]
 
     def count_account(self, body: dict, *, parse: bool = True):
+        """Query execution counts aggregated by account."""
         data = self._http.post("/ExecutionCountAccount/query", json=body).json()
         if not parse:
             return data
@@ -89,6 +135,7 @@ class Runs:
         return [ExecutionCountAccount.parse_obj(r) for r in data.get("result", [])]
 
     def count_group(self, body: dict, *, parse: bool = True):
+        """Query execution counts aggregated by account group."""
         data = self._http.post(
             "/ExecutionCountAccountGroup/query", json=body
         ).json()
@@ -109,6 +156,7 @@ class Runs:
         return [ExecutionCountAccountGroup.parse_obj(r) for r in data.get("result", [])]
 
     def artifacts(self, exec_id: str) -> str:
+        """Return the download URL for execution artifacts."""
         return (
             self._http.post("/ExecutionArtifacts", json={"executionId": exec_id})
             .json()
@@ -123,7 +171,7 @@ class Runs:
         if not parse:
             return data
         if hasattr(GenericConnectorRecord, "model_validate"):
-            return GenericConnectorRecord.model_validate(data)
+            return _GENERIC_PARSER(data)
         return GenericConnectorRecord.parse_obj(data)
 
     def docs(self, body: dict, *, parse: bool = True):
@@ -131,7 +179,7 @@ class Runs:
         if not parse:
             return data
         if hasattr(GenericConnectorRecord, "model_validate"):
-            return [GenericConnectorRecord.model_validate(r) for r in data.get("result", [])]
+            return [_GENERIC_PARSER(r) for r in data.get("result", [])]
         return [GenericConnectorRecord.parse_obj(r) for r in data.get("result", [])]
 
     def docs_more(self, token: str, *, parse: bool = True):
@@ -141,82 +189,155 @@ class Runs:
         if not parse:
             return data
         if hasattr(GenericConnectorRecord, "model_validate"):
-            return [GenericConnectorRecord.model_validate(r) for r in data.get("result", [])]
+            return [_GENERIC_PARSER(r) for r in data.get("result", [])]
         return [GenericConnectorRecord.parse_obj(r) for r in data.get("result", [])]
 
-    def as2_records(self, body: dict):
-        return self._http.post("/AS2ConnectorRecord/query", json=body).json()
+    def as2_records(self, body: dict, *, parse: bool = True):
+        """Query AS2 connector records."""
+        data = self._http.post("/AS2ConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def as2_records_more(self, token: str):
-        return self._http.post(
+    def as2_records_more(self, token: str, *, parse: bool = True):
+        """Get additional AS2 connector records."""
+        data = self._http.post(
             "/AS2ConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def edicustom_records(self, body: dict):
-        return self._http.post("/EdiCustomConnectorRecord/query", json=body).json()
+    def edicustom_records(self, body: dict, *, parse: bool = True):
+        """Query EDI Custom connector records."""
+        data = self._http.post("/EdiCustomConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def edicustom_records_more(self, token: str):
-        return self._http.post(
+    def edicustom_records_more(self, token: str, *, parse: bool = True):
+        """Get additional EDI Custom connector records."""
+        data = self._http.post(
             "/EdiCustomConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def edifact_records(self, body: dict):
-        return self._http.post("/EDIFACTConnectorRecord/query", json=body).json()
+    def edifact_records(self, body: dict, *, parse: bool = True):
+        """Query EDIFACT connector records."""
+        data = self._http.post("/EDIFACTConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def edifact_records_more(self, token: str):
-        return self._http.post(
+    def edifact_records_more(self, token: str, *, parse: bool = True):
+        """Get additional EDIFACT connector records."""
+        data = self._http.post(
             "/EDIFACTConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def hl7_records(self, body: dict):
-        return self._http.post("/HL7ConnectorRecord/query", json=body).json()
+    def hl7_records(self, body: dict, *, parse: bool = True):
+        """Query HL7 connector records."""
+        data = self._http.post("/HL7ConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def hl7_records_more(self, token: str):
-        return self._http.post(
+    def hl7_records_more(self, token: str, *, parse: bool = True):
+        """Get additional HL7 connector records."""
+        data = self._http.post(
             "/HL7ConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def odette_records(self, body: dict):
-        return self._http.post("/ODETTEConnectorRecord/query", json=body).json()
+    def odette_records(self, body: dict, *, parse: bool = True):
+        """Query ODETTE connector records."""
+        data = self._http.post("/ODETTEConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def odette_records_more(self, token: str):
-        return self._http.post(
+    def odette_records_more(self, token: str, *, parse: bool = True):
+        """Get additional ODETTE connector records."""
+        data = self._http.post(
             "/ODETTEConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def oftp2_records(self, body: dict):
-        return self._http.post("/OFTP2ConnectorRecord/query", json=body).json()
+    def oftp2_records(self, body: dict, *, parse: bool = True):
+        """Query OFTP2 connector records."""
+        data = self._http.post("/OFTP2ConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def oftp2_records_more(self, token: str):
-        return self._http.post(
+    def oftp2_records_more(self, token: str, *, parse: bool = True):
+        """Get additional OFTP2 connector records."""
+        data = self._http.post(
             "/OFTP2ConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def rosetta_records(self, body: dict):
-        return self._http.post("/RosettaNetConnectorRecord/query", json=body).json()
+    def rosetta_records(self, body: dict, *, parse: bool = True):
+        """Query RosettaNet connector records."""
+        data = self._http.post("/RosettaNetConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def rosetta_records_more(self, token: str):
-        return self._http.post(
+    def rosetta_records_more(self, token: str, *, parse: bool = True):
+        """Get additional RosettaNet connector records."""
+        data = self._http.post(
             "/RosettaNetConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def tradacoms_records(self, body: dict):
-        return self._http.post("/TradacomsConnectorRecord/query", json=body).json()
+    def tradacoms_records(self, body: dict, *, parse: bool = True):
+        """Query Tradacoms connector records."""
+        data = self._http.post("/TradacomsConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def tradacoms_records_more(self, token: str):
-        return self._http.post(
+    def tradacoms_records_more(self, token: str, *, parse: bool = True):
+        """Get additional Tradacoms connector records."""
+        data = self._http.post(
             "/TradacomsConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def x12_records(self, body: dict):
-        return self._http.post("/X12ConnectorRecord/query", json=body).json()
+    def x12_records(self, body: dict, *, parse: bool = True):
+        """Query X12 connector records."""
+        data = self._http.post("/X12ConnectorRecord/query", json=body).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
-    def x12_records_more(self, token: str):
-        return self._http.post(
+    def x12_records_more(self, token: str, *, parse: bool = True):
+        """Get additional X12 connector records."""
+        data = self._http.post(
             "/X12ConnectorRecord/queryMore", json={"queryToken": token}
         ).json()
+        if not parse:
+            return data
+        return [_GENERIC_PARSER(r) for r in data.get("result", [])]
 
     def log(self, exec_id: str) -> str:
+        """Return the execution log download URL."""
         return (
             self._http.post(
                 "/ProcessLog", json={"executionId": exec_id, "logLevel": "ALL"}
@@ -233,6 +354,7 @@ class Runs:
         return resp.text
 
     def atom_log(self, body: dict) -> str:
+        """Return Atom log download URL."""
         return self._http.post("/AtomLog", json=body).json().get("url")
 
     def as2_artifacts(self, body: dict) -> str:
@@ -242,18 +364,21 @@ class Runs:
         return self._http.post("/AtomWorkerLog", json=body).json().get("url")
 
     def audit(self, aid: str, *, parse: bool = True):
+        """Retrieve a single audit log entry."""
         data = self._http.get(f"/AuditLog/{aid}").json()
         if not parse:
             return data
         return AuditLog.model_validate(data)
 
     def audit_query(self, body: dict, *, parse: bool = True):
+        """Query audit logs."""
         data = self._http.post("/AuditLog/query", json=body).json()
         if not parse:
             return data
         return [AuditLog.model_validate(r) for r in data.get("result", [])]
 
     def audit_query_more(self, token: str, *, parse: bool = True):
+        """Fetch additional audit log results."""
         data = self._http.post(
             "/AuditLog/queryMore", json={"queryToken": token}
         ).json()
@@ -262,12 +387,14 @@ class Runs:
         return [AuditLog.model_validate(r) for r in data.get("result", [])]
 
     def events(self, body: dict, *, parse: bool = True):
+        """Query event logs."""
         data = self._http.post("/Event/query", json=body).json()
         if not parse:
             return data
         return [Event.model_validate(r) for r in data.get("result", [])]
 
     def events_more(self, token: str, *, parse: bool = True):
+        """Fetch additional event log entries."""
         data = self._http.post(
             "/Event/queryMore", json={"queryToken": token}
         ).json()

--- a/boomi/utils.py
+++ b/boomi/utils.py
@@ -1,0 +1,40 @@
+from typing import Callable, Dict, Any, Iterable, Optional
+
+
+def paginate_query(
+    first_call: Callable[[dict], Dict[str, Any]],
+    more_call: Callable[[str], Dict[str, Any]],
+    body: dict,
+    *,
+    parse_item: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    parse: bool = True,
+) -> Iterable[Any]:
+    """Yield items from a paginated query.
+
+    Parameters
+    ----------
+    first_call:
+        Function performing the initial query. It accepts the request body
+        and returns the raw JSON response.
+    more_call:
+        Function performing subsequent ``queryMore`` calls given a token.
+    body:
+        Initial query payload.
+    parse_item:
+        Optional callable used to convert each result item into a model.
+    parse:
+        When ``True`` the ``parse_item`` callable is applied to each item.
+    """
+    data = first_call(body)
+    while True:
+        items = data.get("result", [])
+        if parse and parse_item:
+            for item in items:
+                yield parse_item(item)
+        else:
+            for item in items:
+                yield item
+        token = data.get("queryToken")
+        if not token:
+            break
+        data = more_call(token)

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -92,10 +92,18 @@ Manages process runs and logs.
 
 ```python
 class Runs:
-    def list(self, body: dict)
-    def list_more(self, token: str)
-    def summary(self, body: dict)
-    def connectors(self, body: dict)
+    def list(self, body: dict, parse: bool = True)
+    def list_more(self, token: str, parse: bool = True)
+    def list_all(self, body: dict, parse: bool = True)
+    def summary(self, body: dict, parse: bool = True)
+    def summary_more(self, token: str, parse: bool = True)
+    def summary_all(self, body: dict, parse: bool = True)
+    def connectors(self, body: dict, parse: bool = True)
+    def connectors_more(self, token: str, parse: bool = True)
+    def count_account(self, body: dict, parse: bool = True)
+    def count_group(self, body: dict, parse: bool = True)
+    def as2_records(self, body: dict, parse: bool = True)
+    def hl7_records(self, body: dict, parse: bool = True)
     def artifacts(self, exec_id: str) -> str
     def log(self, exec_id: str) -> str  # Returns log URL
     def atom_log(self, body: dict) -> str

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -134,6 +134,8 @@ environments = client.environments.list()
 ```python
 # List execution records
 runs = client.runs.list(body={"query": {...}})
+# Fetch all pages at once
+all_runs = list(client.runs.list_all(body={"query": {...}}))
 ```
 
 ### More Runs Results
@@ -155,6 +157,8 @@ summary = client.runs.summary(body={"query": {...}})
 ```python
 # Query execution connectors as model objects
 connectors = client.runs.connectors(body={"query": {...}})
+# raw JSON
+raw = client.runs.connectors(body={"query": {...}}, parse=False)
 ```
 
 ### Download Artifacts

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -70,3 +70,19 @@ def test_paginate(monkeypatch):
 
     results = list(http.paginate(first))
     assert results == [1, 2]
+
+
+def test_delete(monkeypatch):
+    http = _HTTP("https://api", ("u", "p"))
+
+    def fake_request(method, url, auth=None, timeout=None, **kw):
+        return make_response(status=204)
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    assert http.delete("/x") is True
+
+    def fake_request_json(method, url, auth=None, timeout=None, **kw):
+        return make_response(status=200, content=b'{"ok": true}')
+
+    monkeypatch.setattr(requests, "request", fake_request_json)
+    assert http.delete("/y") == {"ok": True}

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,7 +5,12 @@ from boomi.models.folder import Folder
 from boomi.models.deployment import Deployment
 from boomi.resources.execute import Execute
 from boomi.resources.runs import Runs
-from boomi.models import ExecuteProcessResponse, ExecutionRecord, ExecutionSummaryRecord
+from boomi.models import (
+    ExecuteProcessResponse,
+    ExecutionRecord,
+    ExecutionSummaryRecord,
+    GenericConnectorRecord,
+)
 
 class DummyResp:
     def __init__(self, data):
@@ -124,6 +129,57 @@ def test_connectors_parse(monkeypatch):
     assert len(items) == 1 and items[0].id == "c1"
     raw = runs.connectors({}, parse=False)
     assert raw["result"][0]["id"] == "c1"
+
+
+def test_connectors_more(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        assert path == "/ExecutionConnector/queryMore"
+        return DummyResp({"result": [{"id": "c2", "executionId": "e"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    items = runs.connectors_more("tok")
+    assert len(items) == 1 and items[0].id == "c2"
+
+
+def test_count_account_group(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        if path.endswith("Account/query"):
+            return DummyResp({"result": [{"accountId": "A"}]})
+        else:
+            return DummyResp({"result": [{"accountId": "B"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    acc = runs.count_account({})
+    grp = runs.count_group({})
+    assert acc[0].account_id == "A"
+    assert grp[0].account_id == "B"
+
+
+def test_special_connector_records(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+
+    def fake_post(path, json=None):
+        return DummyResp({"result": [{"id": "r1", "executionId": "e"}]})
+
+    monkeypatch.setattr(http, "post", fake_post)
+    runs = Runs(http)
+    items = runs.as2_records({})
+    assert isinstance(items[0], GenericConnectorRecord)
+    raw = runs.hl7_records({}, parse=False)
+    assert raw["result"][0]["id"] == "r1"
+
+
+def test_artifacts(monkeypatch):
+    http = _HTTP("base", ("u", "p"))
+    monkeypatch.setattr(http, "post", lambda path, json=None: DummyResp({"url": "http://a"}))
+    runs = Runs(http)
+    assert runs.artifacts("e1") == "http://a"
 
 
 def test_log_url(monkeypatch):


### PR DESCRIPTION
## Summary
- add utility `paginate_query` for handling paginated API calls
- extend `Runs` with generator helpers and typed record queries
- document new methods and usage
- return parsed or raw JSON from special connector queries
- improve `_HTTP.delete` return type
- add docstrings for major resource methods
- extend tests for connectors and new helpers

## Testing
- `pytest -q`